### PR TITLE
Fix event bus logging and guardrail persistence

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -501,6 +501,10 @@ class Task(BaseModel):
                 elif isinstance(guardrail_result.result, TaskOutput):
                     task_output = guardrail_result.result
 
+            result = task_output.raw
+            pydantic_output = task_output.pydantic
+            json_output = task_output.json_dict
+
             self.output = task_output
             self.end_time = datetime.datetime.now()
 

--- a/src/crewai/tools/structured_tool.py
+++ b/src/crewai/tools/structured_tool.py
@@ -282,8 +282,6 @@ class CrewStructuredTool:
         except Exception:
             raise
 
-        result = self.func(**parsed_args, **kwargs)
-
         if asyncio.iscoroutine(result):
             return asyncio.run(result)
 

--- a/src/crewai/utilities/events/crewai_event_bus.py
+++ b/src/crewai/utilities/events/crewai_event_bus.py
@@ -73,8 +73,9 @@ class CrewAIEventsBus:
                     try:
                         handler(source, event)
                     except Exception as e:
+                        handler_name = getattr(handler, "__name__", repr(handler))
                         print(
-                            f"[EventBus Error] Handler '{handler.__name__}' failed for event '{event_type.__name__}': {e}"
+                            f"[EventBus Error] Handler '{handler_name}' failed for event '{event_type.__name__}': {e}"
                         )
 
         self._signal.send(source, event=event)

--- a/tests/test_task_guardrails.py
+++ b/tests/test_task_guardrails.py
@@ -46,6 +46,35 @@ def test_task_with_successful_guardrail_func():
     assert result.raw == "TEST RESULT"
 
 
+def test_guardrail_output_saved():
+    import uuid
+    from pathlib import Path
+
+    def guardrail(result: TaskOutput):
+        return (True, "corrected")
+
+    agent = Mock()
+    agent.role = "test_agent"
+    agent.execute_task.return_value = "original"
+    agent.crew = None
+
+    output_file = f"output_{uuid.uuid4()}.txt"
+
+    task = Task(
+        description="Test task",
+        expected_output="Output",
+        guardrail=guardrail,
+        output_file=output_file,
+    )
+
+    result = task.execute_sync(agent=agent)
+
+    assert result.raw == "corrected"
+    path = Path(output_file)
+    assert path.read_text() == "corrected"
+    path.unlink()
+
+
 def test_task_with_failing_guardrail():
     """Test that failing guardrail triggers retry with error context."""
 

--- a/tests/tools/test_structured_tool.py
+++ b/tests/tools/test_structured_tool.py
@@ -144,6 +144,22 @@ def test_default_values_in_schema():
     )
     assert result == "test custom 42"
 
+
+def test_invoke_calls_function_once():
+    calls = []
+
+    def test_func() -> str:
+        """A test function."""
+        calls.append(True)
+        return "done"
+
+    tool = CrewStructuredTool.from_function(func=test_func, name="test_tool")
+
+    result = tool.invoke({})
+
+    assert result == "done"
+    assert len(calls) == 1
+
 @pytest.fixture
 def custom_tool_decorator():
     from crewai.tools import tool

--- a/tests/utilities/events/test_crewai_event_bus.py
+++ b/tests/utilities/events/test_crewai_event_bus.py
@@ -45,3 +45,23 @@ def test_event_bus_error_handling(capfd):
     out, err = capfd.readouterr()
     assert "Simulated handler failure" in out
     assert "Handler 'broken_handler' failed" in out
+
+
+def test_event_bus_error_handling_without_name(capfd):
+    class CallableHandler:
+        def __repr__(self):
+            return "ClassHandler"
+
+        def __call__(self, source, event):
+            raise ValueError("Simulated handler failure")
+
+    handler = CallableHandler()
+
+    with crewai_event_bus.scoped_handlers():
+        crewai_event_bus.register_handler(BaseEvent, handler)
+        event = TestEvent(type="test_event")
+        crewai_event_bus.emit("source_object", event)
+
+    out, err = capfd.readouterr()
+    assert "Simulated handler failure" in out
+    assert "Handler 'ClassHandler' failed" in out


### PR DESCRIPTION
## Summary
- avoid attribute errors when logging failing event handlers
- persist guardrail-adjusted task outputs to file
- invoke structured tools only once per call

## Testing
- `PYTHONPATH=src pytest tests/utilities/events/test_crewai_event_bus.py::test_event_bus_error_handling_without_name -q`
- `PYTHONPATH=src pytest tests/test_task_guardrails.py::test_guardrail_output_saved -q`
- `PYTHONPATH=src pytest tests/tools/test_structured_tool.py::test_invoke_calls_function_once -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8e3c8dc832bb17f7804e6cbe7bc